### PR TITLE
Clear input and value on loadQuantities

### DIFF
--- a/pages/home/home.browserify.js
+++ b/pages/home/home.browserify.js
@@ -42,7 +42,9 @@ function loadQuantities() {
     quantities = JSON.parse(data)
   }
   var keys = Object.keys(quantities)
-  if (!keys.length) return
+  if (!keys.length) return    
+  $('tr.crypto .qty').val('')
+  $('tr.crypto input.total').val('').removeAttr('data-total')
   keys.forEach(function (key) {
     var $qty = $('tr.crypto.' + key + ' .qty')
     $qty.val(quantities[key])


### PR DESCRIPTION
I occasionally hit an issue on Chrome Android.  Sometimes, after two coins have just switched places on the market cap ranking, the quantity of the coin that I have gets duplicated on the coin now in its place.

So for instance if I have 1.0 of the coin in row number 9, and then there's a change in worth and it swaps places with row number 8, I will have 1.0 of both rows number 8 and 9.

After playing around with it for a while I worked out why this is happening.  
1) Load the cryptonetworth page
2) Do other things for a certain amount of time, until Chrome chooses to discard the page
3) Make a coin you have a quantity input for move place on the list, with a coin you don't have any of taking its place.  I used two static copies of index.html to test this.
4) *possibly* load the cryptonetworth page in another tab, but I'm not sure this is necessary on mobile, making sure it's a fresh version (ie ctrl-f5 if it doesn't show the switched rows)
5) Navigate to the original tab that has the discarded cryptonetworth it will reload with the quantity in both rows.

You can do this on desktop to by using chrome://discards to discard the original page, switching two rows at source, load it in another tab, using ctrl-f5 to make sure you refresh the cache and then clicking back into the discarded tab. Step 4 is definitely required on desktop as otherwise it will use the cache on disk.  My mobile seemed to have jettisoned the disk cache by itself at that stage.  

This commit simply removes all values and data from .qty and .total inputs before repopulating the saved ones during loadQuantities. 